### PR TITLE
Fix typos in config file template for infra-host-ttl

### DIFF
--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -34,6 +34,6 @@ server:
 <% if access.is_a? Array -%>
 <% access.each do |acc| -%><%= "  access-control: #{acc} allow\n" %><% end -%>
 <% elsif access != '' -%><%=   "  access-control: #{access} allow" %><% end -%>
-<% if infra_host_ttl %>
-  infra-host-ttl: <%= infra-host-ttl %>
-<% end %>
+<% if @infra_host_ttl -%>
+  infra-host-ttl: <%= @infra_host_ttl %>
+<% end -%>


### PR DESCRIPTION
Commit 628fc23f364321d7e3e58191a638304bcb658f62 introduced errors due to typos in unbound.conf, mostly mixed up underscores and hyphens. Here's a pull request to correct those issues.

Also, better to use @variable in erb templates so that variables set to undef are properly set as undefined instead of being rendered as the string "undef."

This is the error I got:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template unbound/unbound.conf.erb:
  Filepath: /usr/lib/ruby/site_ruby/1.8/puppet/parser/templatewrapper.rb
  Line: 81
  Detail: Could not find value for 'infra_host' at /etc/puppet/modules/unbound/templates/unbound.conf.erb:38
 at /etc/puppet/modules/unbound/manifests/init.pp:54 on node scientific4.localdomain
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```
