### PR TITLE
(maint) Add OpenBSD support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,32 +3,30 @@
 # Installs and configures Unbound, the caching DNS resolver from NLnet Labs
 #
 class unbound (
-  $verbosity = 1,
-  $interface = ['::0','0.0.0.0'],
-  $access    = ['::1','127.0.0.1/8'],
-  $do_ip4    = true,
-  $do_ip6    = true,
-  $interface_automatic = false,
-  $outgoing_interface = undef,
-  $extended_statistics = no,
-  $statistics_interval = 0,
+  $verbosity             = 1,
+  $interface             = ['::0','0.0.0.0'],
+  $access                = ['::1','127.0.0.1/8'],
+  $do_ip4                = true,
+  $do_ip6                = true,
+  $interface_automatic   = false,
+  $outgoing_interface    = undef,
+  $extended_statistics   = no,
+  $statistics_interval   = 0,
   $statistics_cumulative = false,
-  $control_enable = 'no',
-  $num_threads = 1,
-  $private_domain = undef,
-  $prefetch = false,
-  $infra_host_ttl = undef,
-  $port = 53
-) {
-  include unbound::params
-
-  # Localize some variables
-  $unbound_package     = $unbound::params::unbound_package
-  $unbound_confdir     = $unbound::params::unbound_confdir
-  $unbound_logdir      = $unbound::params::unbound_logdir
-  $unbound_service     = $unbound::params::unbound_service
-  $unbound_anchor_file = $unbound::params::unbound_anchor_file
-  $unbound_hints_file  = $unbound::params::unbound_hints_file
+  $control_enable        = 'no',
+  $num_threads           = 1,
+  $private_domain        = undef,
+  $prefetch              = false,
+  $infra_host_ttl        = undef,
+  $port                  = 53,
+  $unbound_package       = $unbound::params::unbound_package,
+  $unbound_confdir       = $unbound::params::unbound_confdir,
+  $unbound_logdir        = $unbound::params::unbound_logdir,
+  $unbound_service       = $unbound::params::unbound_service,
+  $unbound_anchor_file   = $unbound::params::unbound_anchor_file,
+  $unbound_hints_file    = $unbound::params::unbound_hints_file,
+  $unbound_owner         = $unbound::params::owner,
+) inherits unbound::params {
 
   $provider = $::kernel ? {
     Darwin  => 'macports',
@@ -49,10 +47,11 @@ class unbound (
   }
 
   $root_hints_url = 'http://www.internic.net/domain/named.root'
+
   exec { 'download-roothints':
     command => "curl -o ${unbound_confdir}/${unbound_hints_file} ${root_hints_url}",
     creates => "${unbound_confdir}/${unbound_hints_file}",
-    path    => ['/usr/bin'],
+    path    => ['/usr/bin','/usr/local/bin'],
     before  => [ Concat::Fragment['unbound-header'] ],
   }
 
@@ -74,7 +73,7 @@ class unbound (
 
   # Initialize the root key file if it doesn't already exist.
   file { "${unbound_confdir}/${unbound_anchor_file}":
-    owner   => 'unbound',
+    owner   => $owner,
     group   => 0,
     content => '. IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5',
     replace => false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class unbound::params {
       $unbound_service     = 'unbound'
       $unbound_package     = 'unbound'
       $unbound_anchor_file = 'root.key'
+      $owner               = 'unbound'
     }
     'redhat', 'centos', 'scientific': {
       $unbound_confdir     = '/etc/unbound'
@@ -18,6 +19,7 @@ class unbound::params {
       $unbound_service     = 'unbound'
       $unbound_package     = 'unbound'
       $unbound_anchor_file = 'root.anchor'
+      $owner               = 'unbound'
       }
     'darwin': {
       $unbound_confdir     = '/opt/local/etc/unbound'
@@ -25,6 +27,7 @@ class unbound::params {
       $unbound_service     = 'org.macports.unbound'
       $unbound_package     = 'unbound'
       $unbound_anchor_file = 'root.key'
+      $owner               = 'unbound'
     }
     'freebsd': {
       $unbound_confdir     = '/usr/local/etc/unbound'
@@ -32,6 +35,15 @@ class unbound::params {
       $unbound_service     = 'unbound'
       $unbound_package     = 'dns/unbound'
       $unbound_anchor_file = 'root.key'
+      $owner               = 'unbound'
+    }
+    'openbsd': {
+      $unbound_confdir     = '/var/unbound/etc'
+      $unbound_logdir      = '/var/log/unbound'
+      $unbound_service     = 'unbound'
+      $unbound_package     = 'unbound'
+      $unbound_anchor_file = 'root.key'
+      $owner               = '_unbound'
     }
   }
 


### PR DESCRIPTION
This adds the parameters for OpenBSD and adjusts the server manifest
slightly to support OpenBSD specific items.
