### PR TITLE
(maint) Change parameter names and cleanup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,8 @@ A puppet module for the Unbound caching resolver.
 
 * Debian
 * FreeBSD
-* OS X
+* OpenBSD
+* OS X (macports)
 * RHEL clones (with EPEL)
 
 ## Requirements
@@ -16,16 +17,19 @@ The `concat` module must be installed. It can be obtained from Puppet Forge:
 
     puppet module install ripienaar/concat
 
+Or add this line to your `Puppetfile` and deploy with [R10k](https://github.com/adrienthebo/r10k):
+
+    mod 'concat', :git => 'git://github.com/ripienaar/puppet-concat.git'
+
 ## Usage
 
 ### Server Setup
 
 At minimum you should setup the interfaces to listen on and allow access to a few subnets.
 
-    class {
-      "unbound":
-        interface => ["::0","0.0.0.0"],
-        access    => ["10.0.0.0/20","::1"],
+    class { "unbound":
+      interface => ["::0","0.0.0.0"],
+      access    => ["10.0.0.0/20","::1"],
     }
 
 ### Stub Zones
@@ -58,11 +62,33 @@ For overriding DNS record in zone.
 
 ### Forward Zones
 
-For external domains resolving:
+Setup a forward zone with a list of address from which you should resolve queries.  You can configure a forward zone with something like the following:
 
     unbound::forward { '.':
       address => [
-                  '8.8.8.8',
-                  '8.8.4.4'
-                 ]
+        '8.8.8.8',
+        '8.8.4.4'
+        ]
     }
+
+This means that your server will use the Google DNS servers for any
+zones that it doesn't know how to reach and cache the result.
+
+### Remote Control
+
+The Unbound remote control the use of the unbound-control utility to
+issue commands to the Unbound daemon process.
+
+    include unbound::remote
+
+On some platforms this is needed to function correctly.
+
+## More information
+
+You can find more information about Unbound and its configuration items at
+[unbound.net](http://unbound.net).
+
+## Contribute
+
+Please help me make this module awesome!  Send pull requests and file issues.
+

--- a/manifests/forward.pp
+++ b/manifests/forward.pp
@@ -1,15 +1,19 @@
-# Create an unbound forward zone
+# Class: unbound::forward
+#
+# Configures a zone for DNS forwarding
+#
 define unbound::forward (
   $address,
 ) {
 
   include unbound::params
 
-  $unbound_confdir = $unbound::params::unbound_confdir
+  $config_file = $unbound::params::config_file
+  $zone        = $name
 
   concat::fragment { "unbound-forward-${name}":
     order   => '05',
-    target  => "${unbound_confdir}/unbound.conf",
+    target  => $config_file,
     content => template('unbound/forward.erb'),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,70 +13,67 @@ class unbound (
   $extended_statistics   = no,
   $statistics_interval   = 0,
   $statistics_cumulative = false,
-  $control_enable        = 'no',
+  $control_enable        = false,
   $num_threads           = 1,
   $private_domain        = undef,
   $prefetch              = false,
   $infra_host_ttl        = undef,
   $port                  = 53,
-  $unbound_package       = $unbound::params::unbound_package,
-  $unbound_confdir       = $unbound::params::unbound_confdir,
-  $unbound_logdir        = $unbound::params::unbound_logdir,
-  $unbound_service       = $unbound::params::unbound_service,
-  $unbound_anchor_file   = $unbound::params::unbound_anchor_file,
-  $unbound_hints_file    = $unbound::params::unbound_hints_file,
-  $unbound_owner         = $unbound::params::owner,
+  $confdir               = $unbound::params::confdir,
+  $config_file           = $unbound::params::config_file,
+  $logdir                = $unbound::params::logdir,
+  $service_name          = $unbound::params::service_name,
+  $package_name          = $unbound::params::package_name,
+  $package_provider      = $unbound::params::package_provider,
+  $anchor_file           = $unbound::params::anchor_file,
+  $hints_file            = $unbound::params::hints_file,
+  $owner                 = $unbound::params::owner,
+  $root_hints_url        = 'http://www.internic.net/domain/named.root'
 ) inherits unbound::params {
 
-  $provider = $::kernel ? {
-    Darwin  => 'macports',
-    default => undef,
-  }
-
-  package { $unbound_package:
+  package { $package_name:
     ensure   => installed,
-    provider => $provider,
+    provider => $package_provider,
   }
 
-  service { $unbound_service:
+  service { $service_name:
     ensure    => running,
-    name      => $unbound_service,
+    name      => $service_name,
     enable    => true,
     hasstatus => false,
-    require   => Package[$unbound_package],
+    require   => Package[$package_name],
   }
 
-  $root_hints_url = 'http://www.internic.net/domain/named.root'
 
   exec { 'download-roothints':
-    command => "curl -o ${unbound_confdir}/${unbound_hints_file} ${root_hints_url}",
-    creates => "${unbound_confdir}/${unbound_hints_file}",
+    command => "curl -o ${confdir}/${hints_file} ${root_hints_url}",
+    creates => "${confdir}/${hints_file}",
     path    => ['/usr/bin','/usr/local/bin'],
     before  => [ Concat::Fragment['unbound-header'] ],
   }
 
-  file { "${unbound_confdir}/${unbound_hints_file}":
+  file { "${confdir}/${hints_file}":
     mode => '0444',
   }
 
   concat::fragment { 'unbound-header':
     order   => '00',
-    target  => "${unbound_confdir}/unbound.conf",
+    target  => $config_file,
     content => template('unbound/unbound.conf.erb'),
-    require => Package[$unbound_package],
   }
 
-  concat { "${unbound_confdir}/unbound.conf":
-    notify  => Service[$unbound_service],
-    require => Package[$unbound_package],
+  concat { $config_file:
+    notify  => Service[$service_name],
+    require => Package[$package_name],
   }
 
   # Initialize the root key file if it doesn't already exist.
-  file { "${unbound_confdir}/${unbound_anchor_file}":
-    owner   => $unbound_owner,
+  file { "${confdir}/${anchor_file}":
+    owner   => $owner,
     group   => 0,
     content => '. IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5',
     replace => false,
-    require => Package[$unbound_package],
+    require => Package[$package_name],
   }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,46 +6,48 @@ class unbound::params {
 
   case $::operatingsystem {
     'ubuntu', 'debian': {
-      $unbound_confdir     = '/etc/unbound'
-      $unbound_logdir      = '/var/log'
-      $unbound_service     = 'unbound'
-      $unbound_package     = 'unbound'
-      $unbound_anchor_file = 'root.key'
-      $owner               = 'unbound'
+      $confdir      = '/etc/unbound'
+      $logdir       = '/var/log'
+      $service_name = 'unbound'
+      $package_name = 'unbound'
+      $anchor_file  = 'root.key'
+      $owner        = 'unbound'
     }
     'redhat', 'centos', 'scientific': {
-      $unbound_confdir     = '/etc/unbound'
-      $unbound_logdir      = '/var/log'
-      $unbound_service     = 'unbound'
-      $unbound_package     = 'unbound'
-      $unbound_anchor_file = 'root.anchor'
-      $owner               = 'unbound'
+      $confdir      = '/etc/unbound'
+      $logdir       = '/var/log'
+      $service_name = 'unbound'
+      $package_name = 'unbound'
+      $anchor_file  = 'root.anchor'
+      $owner        = 'unbound'
       }
     'darwin': {
-      $unbound_confdir     = '/opt/local/etc/unbound'
-      $unbound_logdir      = '/opt/local/var/log/unbound'
-      $unbound_service     = 'org.macports.unbound'
-      $unbound_package     = 'unbound'
-      $unbound_anchor_file = 'root.key'
-      $owner               = 'unbound'
+      $confdir          = '/opt/local/etc/unbound'
+      $logdir           = '/opt/local/var/log/unbound'
+      $service_name     = 'org.macports.unbound'
+      $package_name     = 'unbound'
+      $package_provider = 'macports'
+      $anchor_file      = 'root.key'
+      $owner            = 'unbound'
     }
     'freebsd': {
-      $unbound_confdir     = '/usr/local/etc/unbound'
-      $unbound_logdir      = '/var/log/unbound'
-      $unbound_service     = 'unbound'
-      $unbound_package     = 'dns/unbound'
-      $unbound_anchor_file = 'root.key'
-      $owner               = 'unbound'
+      $confdir      = '/usr/local/etc/unbound'
+      $logdir       = '/var/log/unbound'
+      $service_name = 'unbound'
+      $package_name = 'dns/unbound'
+      $anchor_file  = 'root.key'
+      $owner        = 'unbound'
     }
     'openbsd': {
-      $unbound_confdir     = '/var/unbound/etc'
-      $unbound_logdir      = '/var/log/unbound'
-      $unbound_service     = 'unbound'
-      $unbound_package     = 'unbound'
-      $unbound_anchor_file = 'root.key'
-      $owner               = '_unbound'
+      $confdir      = '/var/unbound/etc'
+      $logdir       = '/var/log/unbound'
+      $service_name = 'unbound'
+      $package_name = 'unbound'
+      $anchor_file  = 'root.key'
+      $owner        = '_unbound'
     }
   }
 
-  $unbound_hints_file = 'root.hints'
+  $config_file = "${confdir}/unbound.conf"
+  $hints_file  = 'root.hints'
 }

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -1,19 +1,20 @@
 # Class: unbound::record
 #
-# Create an unbound static dns record to override upstreams
+# Create an unbound static DNS record override
 #
 define unbound::record (
   $content,
   $ttl  = '14400',
   $type = 'A'
 ) {
+
   include unbound::params
 
-  $unbound_confdir = $unbound::params::unbound_confdir
+  $config_file = $unbound::params::config_file
 
   concat::fragment { "unbound-stub-${name}-local-record":
     order   => '02',
-    target  => "${unbound_confdir}/unbound.conf",
+    target  => $config_file,
     content => "  local-data: \"${name} ${ttl} IN ${type} ${content}\"\n",
   }
 }

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -3,6 +3,7 @@
 # Configure remote control of the unbound daemon process
 #
 class unbound::remote (
+  $enable            = true,
   $interface         = ['::1', '127.0.0.1'],
   $port              = 953,
   $server_key_file   = undef,
@@ -10,13 +11,14 @@ class unbound::remote (
   $control_key_file  = undef,
   $control_cert_file = undef
 ) {
+
   include unbound::params
 
-  $unbound_confdir = "${unbound::params::unbound_confdir}/"
+  $config_file = $unbound::params::config_file
 
   concat::fragment { 'unbound-remote':
     order   => 10,
-    target  => "${unbound_confdir}unbound.conf",
+    target  => $config_file,
     content => template('unbound/remote.erb'),
   }
 }

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -1,32 +1,33 @@
 # Class: unbound::stub
 #
-# Create an unbound stub zone for caching upstream name resolvers.
+# Create an unbound stub zone for caching upstream name resolvers
 #
 define unbound::stub (
   $address,
   $insecure = false
 ) {
+
   include unbound::params
 
-  $unbound_confdir = $unbound::params::unbound_confdir
+  $config_file = $unbound::params::config_file
 
   concat::fragment { "unbound-stub-${name}":
     order   => '05',
-    target  => "${unbound_confdir}/unbound.conf",
+    target  => $config_file,
     content => template('unbound/stub.erb'),
   }
 
   if $insecure == true {
     concat::fragment { "unbound-stub-${name}-insecure":
       order   => '01',
-      target  => "${unbound_confdir}/unbound.conf",
+      target  => $config_file,
       content => "  domain-insecure: \"${name}\"\n",
     }
   }
 
   concat::fragment { "unbound-stub-${name}-local-zone":
     order   => '02',
-    target  => "${unbound_confdir}/unbound.conf",
+    target  => $config_file,
     content => "  local-zone: \"${name}\" transparent \n",
   }
 }

--- a/templates/forward.erb
+++ b/templates/forward.erb
@@ -1,5 +1,5 @@
 forward-zone:
-  name: "<%= @name %>"
+  name: "<%= @zone %>"
 <% if @address.is_a? Array -%>
 <% @address.each do |addr| -%><%= "  forward-addr: #{addr}\n" %><% end -%>
 <% elsif @address != '' -%>

--- a/templates/remote.erb
+++ b/templates/remote.erb
@@ -1,5 +1,9 @@
 remote-control:
+<% if @enable -%>
   control-enable: yes
+<% else -%>
+  control-enable: no
+<% end -%>
 <% if @interface.is_a? Array -%>
 <% @interface.each do |int| -%>
   control-interface: <%= int %>

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -1,14 +1,11 @@
-remote-control:
-  control-enable: <%= @control_enable %>
-
 server:
   verbosity: <%= @verbosity %>
-  auto-trust-anchor-file: <%= @unbound_confdir %>/<%= @unbound_anchor_file %>
+  auto-trust-anchor-file: <%= @confdir %>/<%= @anchor_file %>
   do-not-query-localhost: no
   use-syslog: yes
   extended-statistics: <%= @extended_statistics %>
   statistics-interval: <%= @statistics_interval %>
-  root-hints: <%= @unbound_confdir %>/<%= @unbound_hints_file %>
+  root-hints: <%= @confdir %>/<%= @hints_file %>
 <% if @statistics_cumulative -%>
   statistics-cumulative: yes
 <% end -%>


### PR DESCRIPTION
This work udpates the parameter names for less typing and overall
cleaner code.  There are some README udpates to give a bit more
information as well as some fixes of some unused code.

Note, you may have to update your parameter names, though most of the
param names were internal and most likely would not need overwriting.
