### PR TITLE
using "name" as parameter in types makes life difficult

### DIFF
--- a/manifests/forward.pp
+++ b/manifests/forward.pp
@@ -4,12 +4,12 @@
 #
 define unbound::forward (
   $address,
+  $zone = $name,
 ) {
 
   include unbound::params
 
   $config_file = $unbound::params::config_file
-  $zone        = $name
 
   concat::fragment { "unbound-forward-${name}":
     order   => '05',

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -6,24 +6,25 @@ define unbound::record (
   $content,
   $ttl     = '14400',
   $type    = 'A',
-  $reverse = false
+  $reverse = false,
+  $entry   = $name
 ) {
 
   include unbound::params
 
   $config_file = $unbound::params::config_file
 
-  $local_data     = "  local-data: \"${name} ${ttl} IN ${type} ${content}\"\n"
-  $local_data_ptr = "  local-data-ptr: \"${content} ${name}\"\n"
+  $local_data     = "  local-data: \"${entry} ${ttl} IN ${type} ${content}\"\n"
+  $local_data_ptr = "  local-data-ptr: \"${content} ${entry}\"\n"
 
-  $entry = $reverse? {
+  $config = $reverse? {
     true    => "${local_data}${local_data_ptr}",
     default => $local_data,
   }
 
-  concat::fragment { "unbound-stub-${name}-local-record":
+  concat::fragment { "unbound-stub-${title}-local-record":
     order   => '02',
     target  => $config_file,
-    content => $entry,
+    content => $config,
   }
 }


### PR DESCRIPTION
if we want to create the same entry for different IP addresses (round
robin, or IPv4 vs IPv6) using name as signifyer makes ones life patently
difficult in puppet, because it will assume we are trying to alias
something that already exits under a different name.
