### PR TITLE
unbound header is out of order with concat setup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,15 +56,15 @@ class unbound (
     mode => '0444',
   }
 
+  concat { $config_file:
+    notify  => Service[$service_name],
+    require => Package[$package_name],
+  }
+
   concat::fragment { 'unbound-header':
     order   => '00',
     target  => $config_file,
     content => template('unbound/unbound.conf.erb'),
-  }
-
-  concat { $config_file:
-    notify  => Service[$service_name],
-    require => Package[$package_name],
   }
 
   # Initialize the root key file if it doesn't already exist.


### PR DESCRIPTION
it appears that the first concat::fragment must not occur in before the
first call to concat itself.
This is what issues the call to concat::setup, without which we don't
know in which directory to place the header's fragment file.
concat::fragment will attempt to place it into

  /_etc_unbound_unbound.conf/fragments/00_unbound-header
