### PR TITLE
Add support for the prefetch-key option.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class unbound (
   $num_threads            = 1,
   $private_domain         = undef,
   $prefetch               = false,
+  $prefetch_key           = false,
   $infra_host_ttl         = undef,
   $port                   = 53,
   $confdir                = $unbound::params::confdir,

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -13,6 +13,9 @@ server:
 <% if @prefetch -%>
   prefetch: yes
 <% end -%>
+<% if @prefetch_key -%>
+  prefetch-key: yes
+<% end -%>
 <% if @private_domain -%>
   private-domain: "<%= @private_domain %>"
 <% end -%>


### PR DESCRIPTION
- `prefetch-key`: <yes or no>:
            If yes, fetch the DNSKEYs earlier  in  the  validation  process,
            when  a  DS  record  is encountered.  This lowers the latency of
            requests.  It does use a little more CPU.  Also if the cache  is
            set to 0, it is no use. Default is no.
