### PR TITLE
OS specific client to fetch root hints and edns buffer size option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,9 @@ namespace :ci do
     linter = PuppetLint.new
     linter.configuration.log_format =
         '%{path}:%{linenumber}:%{check}:%{KIND}:%{message}'
-
+    linter.configuration.send('disable_class_inherits_from_params_class')
+    linter.configuration.send('disable_80chars')
+    linter.configuration.send('disable_autoloader_layout')
     lintrc = ".puppet-lintrc"
     if File.file?(lintrc)
       File.read(lintrc).each_line do |line|

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class unbound (
   $private_domain         = undef,
   $prefetch               = false,
   $infra_host_ttl         = undef,
+  $edns_buffer_size       = undef,
   $port                   = 53,
   $confdir                = $unbound::params::confdir,
   $config_file            = $unbound::params::config_file,
@@ -28,6 +29,7 @@ class unbound (
   $anchor_file            = $unbound::params::anchor_file,
   $hints_file             = $unbound::params::hints_file,
   $owner                  = $unbound::params::owner,
+  $fetch_client           = $unbound::params::fetch_client,
   $root_hints_url         = 'http://www.internic.net/domain/named.root',
   $msg_cache_slabs        = undef,
   $rrset_cache_slabs      = undef,
@@ -55,9 +57,8 @@ class unbound (
     require   => Package[$package_name],
   }
 
-
   exec { 'download-roothints':
-    command => "curl -o ${confdir}/${hints_file} ${root_hints_url}",
+    command => "${fetch_client} ${confdir}/${hints_file} ${root_hints_url}",
     creates => "${confdir}/${hints_file}",
     path    => ['/usr/bin','/usr/local/bin'],
     before  => [ Concat::Fragment['unbound-header'] ],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class unbound::params {
       $package_name = 'unbound'
       $anchor_file  = 'root.key'
       $owner        = 'unbound'
+      $fetch_client = 'wget -O'
     }
     'redhat', 'centos', 'scientific': {
       $confdir      = '/etc/unbound'
@@ -20,6 +21,7 @@ class unbound::params {
       $package_name = 'unbound'
       $anchor_file  = 'root.anchor'
       $owner        = 'unbound'
+      $fetch_client = 'wget -O'
       }
     'darwin': {
       $confdir          = '/opt/local/etc/unbound'
@@ -29,6 +31,7 @@ class unbound::params {
       $package_provider = 'macports'
       $anchor_file      = 'root.key'
       $owner            = 'unbound'
+      $fetch_client     = 'curl -o'
     }
     'freebsd': {
       $confdir      = '/usr/local/etc/unbound'
@@ -37,6 +40,7 @@ class unbound::params {
       $package_name = 'dns/unbound'
       $anchor_file  = 'root.key'
       $owner        = 'unbound'
+      $fetch_client = 'fetch -o'
     }
     'openbsd': {
       $confdir      = '/var/unbound/etc'
@@ -45,6 +49,16 @@ class unbound::params {
       $package_name = 'unbound'
       $anchor_file  = 'root.key'
       $owner        = '_unbound'
+      $fetch_client = 'fetch -o'
+    }
+    default: {
+      $confdir      = '/etc/unbound'
+      $logdir       = '/var/log'
+      $service_name = 'unbound'
+      $package_name = 'unbound'
+      $anchor_file  = 'root.key'
+      $owner        = 'unbound'
+      $fetch_client = 'wget -O'
     }
   }
 

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -9,6 +9,9 @@ server:
 <% if @statistics_cumulative -%>
   statistics-cumulative: yes
 <% end -%>
+<% if @edns_buffer_size -%>
+  edns-buffer-size: <%= @edns_buffer_size %>
+<% end -%>
   num-threads: <%= @num_threads %>
 <% if @prefetch -%>
   prefetch: yes


### PR DESCRIPTION
Curl is not installed by default everywhere this option uses the default client for a specific os.  It also adds the ability to specify an edns_buffer_size
