### PR TITLE
add hide_identity and hide_version parameters, and update the

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,9 @@ class unbound (
   $num_queries_per_thread = undef,
   $outgoing_range         = undef,
   $so_rcvbuf              = undef,
-  $tcp_upstream           = false
+  $tcp_upstream           = false,
+  $hide_identity          = true,
+  $hide_version           = true,
 ) inherits unbound::params {
 
   package { $package_name:

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -81,3 +81,13 @@ server:
 <% if @tcp_upstream -%>
   tcp-upstream: yes
 <% end -%>
+<% if @hide_identity -%>
+  hide-identity: yes
+<% else -%>
+  hide-identity: no
+<% end -%>
+<% if @hide_version -%>
+  hide-version: yes
+<% else -%>
+  hide-version: no
+<% end -%>


### PR DESCRIPTION
template to add those parameters to the server: configuration.

default for both variables is true, since there should not really be a need to give that information out to the clients if they ask, the administrator should know what DNS server is running ;)
