### PR TITLE
Add support for OpenBSD 5.6 and future, 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,9 +45,14 @@ class unbound (
   $tcp_upstream           = false
 ) inherits unbound::params {
 
-  package { $package_name:
-    ensure   => installed,
-    provider => $package_provider,
+  if $package_name {
+    package { $package_name:
+      ensure   => installed,
+      provider => $package_provider,
+    }
+    Package["$package_name"] -> Service["$service_name"]
+    Package["$package_name"] -> Concat["$config_file"]
+    Package["$package_name"] -> File["${confdir}/${anchor_file}"]
   }
 
   service { $service_name:
@@ -55,7 +60,6 @@ class unbound (
     name      => $service_name,
     enable    => true,
     hasstatus => false,
-    require   => Package[$package_name],
   }
 
   exec { 'download-roothints':
@@ -71,7 +75,6 @@ class unbound (
 
   concat { $config_file:
     notify  => Service[$service_name],
-    require => Package[$package_name],
   }
 
   concat::fragment { 'unbound-header':
@@ -86,7 +89,6 @@ class unbound (
     group   => 0,
     content => '. IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5',
     replace => false,
-    require => Package[$package_name],
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,11 @@ class unbound::params {
       $confdir      = '/var/unbound/etc'
       $logdir       = '/var/log/unbound'
       $service_name = 'unbound'
-      $package_name = 'unbound'
+      if versioncmp($::operatingsystemrelease, '5.6') < 0 {
+        $package_name = 'unbound'
+      } else {
+        $package_name = undef
+      }
       $anchor_file  = 'root.key'
       $owner        = '_unbound'
       $fetch_client = 'ftp -o'


### PR DESCRIPTION
which apparently ships unbound in the base system, and doesn't need to install a package
anymore.

In params.pp checking the operatingsystemrelease, to make the decision
whether to install the unbound package (version < 5.6) or not.

in init.pp, only install the package when package_name is defined,
and switch require statements into chained orders within that
same if statement.
