### PR TITLE
add metadata.json (before new release)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,6 +54,42 @@
         "12.04",
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "5.3",
+        "6.1",
+        "7.1"
+      ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "10",
+        "9.3",
+        "8.4"
+      ]
+    },
+    {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "5.5"
+      ]
+    },
+    {
+      "operatingsystem": "NetBSD",
+      "operatingsystemrelease": [
+        "6.1.4",
+        "5.2.2"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
metadata.json is now required on the forge.
further, the forge recommends we add compatibility information as far as
possible. this file is essentially copied from puppetlabs-apache.
