### PR TITLE
Clean up some newline issues

### DIFF
--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -1,9 +1,5 @@
 stub-zone:
   name: "<%= @name %>"
-<% if @address.is_a? Array -%>
-<% @address.each do |addr| -%>
+<% Array(@address).each do |addr| -%>
   stub-addr: <%= addr %>
-<% end -%>
-<% elsif @address != '' -%>
-  stub-addr: <%= @address -%>
 <% end -%>


### PR DESCRIPTION
Not having the newline was preventing my unbound server from reading the
configuration correctly.  This ammends the previos epic PR to include
newlines.  While I was at it, I devided to squash the logic to avoid
checking for an array.
