### PR TITLE
Protect the second reference to $package_name in manifests/init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,7 @@ class unbound (
   $verbosity                    = $unbound::params::verbosity,
 ) inherits unbound::params {
 
+
   if $package_name {
     package { $package_name:
       ensure   => installed,
@@ -89,13 +90,17 @@ class unbound (
     before  => [ Concat::Fragment['unbound-header'] ],
   }
 
+  $require = $package_name ? {
+    false   => undef,
+    default => Package[$package_name],
+  }
   file { [
     $confdir,
     $conf_d,
     $keys_d
-    ]:
+  ]:
     ensure  => directory,
-    require => Package[$package_name],
+    require => $require,
   }
 
   file { $hints_file:


### PR DESCRIPTION
The first one is already wrapped in an if { } block. By doing the same for the second reference, it becomes possible to set $package_name to false, allowing for the management of the actual installation of the unbound package external to this module. That can be useful if you want to get specific versions, etc.
