### PR TITLE
Add test for unbound::stub

### DIFF
--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -32,7 +32,7 @@ define unbound::stub (
   Variant[Array[Unbound::Address], Unbound::Address] $address,
   Variant[Boolean, Enum['true', 'false']]            $insecure    = false,
   Unbound::Local_zone_type                           $type        = 'transparent',
-  Stdlib::Unixpath                                   $config_file = $unbound::config_file,
+  Stdlib::Unixpath                                   $config_file = lookup('unbound::config_file'),
 ) {
 
   concat::fragment { "unbound-stub-${name}":

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -32,7 +32,7 @@ define unbound::stub (
   Variant[Array[Unbound::Address], Unbound::Address] $address,
   Variant[Boolean, Enum['true', 'false']]            $insecure    = false,
   Unbound::Local_zone_type                           $type        = 'transparent',
-  Unix::Path                                         $config_file = $unbound::config_file,
+  Stdlib::Unixpath                                   $config_file = $unbound::config_file,
 ) {
 
   concat::fragment { "unbound-stub-${name}":

--- a/spec/defines/stub_spec.rb
+++ b/spec/defines/stub_spec.rb
@@ -7,7 +7,14 @@ describe 'unbound::stub' do
     context "on #{os}" do
       let(:facts) { facts }
 
+      let(:params) do
+        {
+          address: ['::1']
+        }
+      end
+
       it { is_expected.to contain_unbound__stub('lab.example.com') }
+      it { is_expected.to contain_concat__fragment('unbound-stub-lab.example.com') }
     end
   end
 end

--- a/spec/defines/stub_spec.rb
+++ b/spec/defines/stub_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'unbound::stub' do
+  let(:title) { 'lab.example.com' }
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to contain_unbound__stub('lab.example.com') }
+    end
+  end
+end

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -1,11 +1,5 @@
 stub-zone:
   name: "<%= @name %>"
-<% if @address -%>
-<% addrs = PuppetX::Unbound::ValidateAddrs.new(@address) -%>
-<% addrs.name_list.each do |addr| -%>
-  stub-host: <%= addr %>
-<% end -%>
-<% addrs.ip_list.each do |addr| -%>
+<% @address.each do |addr| -%>
   stub-addr: <%= addr %>
-<% end -%>
 <% end -%>


### PR DESCRIPTION
Without this change, there is no facility to know if changes to the
unbound::stub define cause issues on any of our platforms.  Here we ensure a
simple test catches the compile failures.
