### PR TITLE
Purge unmanaged configuration files

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -184,5 +184,5 @@ unbound::secret_seed: default
 unbound::redis_server_host: 127.0.0.1
 unbound::redis_server_port: 6379
 unbound::redis_timeout: 100
-
-
+unbound::unbound_conf_d: "%{hiera('unbound::confdir')}/unbound.conf.d"
+unbound::purge_unbound_conf_d: false

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,3 +1,4 @@
 ---
 unbound::pidfile: '/run/unbound.pid'
 unbound::runtime_dir: '/var/lib/unbound'
+unbound::purge_unbound_conf_d: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -153,6 +153,7 @@ class unbound (
   String                                               $package_name,
   Optional[String]                                     $package_provider,
   String                                               $package_ensure,
+  Boolean                                              $purge_unbound_conf_d,
   String                                               $root_hints_url,
   Stdlib::Absolutepath                                 $runtime_dir,
   String                                               $service_name,
@@ -182,6 +183,7 @@ class unbound (
   String                                               $redis_server_host,
   Integer[1,65536]                                     $redis_server_port,
   Integer[1]                                           $redis_timeout,
+  Stdlib::Absolutepath                                 $unbound_conf_d,
 ) {
 
   unless $package_name.empty {
@@ -266,6 +268,15 @@ class unbound (
     mode   => '0444',
   }
 
+  # purge unmanaged files in configuration directory
+  file { $unbound_conf_d:
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    purge   => $purge_unbound_conf_d,
+    recurse => $purge_unbound_conf_d,
+  }
+
   concat { $config_file:
     validate_cmd => $validate_cmd,
     notify       => Service[$service_name],
@@ -294,5 +305,4 @@ class unbound (
   if $record {
     create_resources('unbound::record', $record)
   }
-
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,6 +9,7 @@ describe 'unbound' do
       let(:package) { 'unbound' }
       let(:conf_file) { "#{conf_dir}/unbound.conf" }
       let(:conf_d_dir) { "#{conf_dir}/conf.d" }
+      let(:unbound_conf_d) { "#{conf_dir}/unbound.conf.d" }
       let(:keys_d_dir) { "#{conf_dir}/keys.d" }
       let(:hints_file) { "#{conf_dir}/root.hints" }
 
@@ -67,6 +68,15 @@ describe 'unbound' do
         it { is_expected.to contain_file(conf_d_dir) }
         it { is_expected.to contain_file(keys_d_dir) }
         it { is_expected.to contain_file(hints_file) }
+        it do
+          is_expected.to contain_file(unbound_conf_d).with(
+            'ensure'  => 'directory',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'purge'   => false,
+            'recurse' => false
+          )
+        end
         it { is_expected.not_to contain_file('/run') }
         it { is_expected.not_to contain_file('/var/run') }
         if pidfile =~ %r{unbound/unbound\.pid\Z}


### PR DESCRIPTION
Debian package for Unbound creates two additional configurations in **/etc/unbound/unbound.conf.d** where are some Unbound options duplicated. Please take a look on #223 for more information. This PR introduce a logic how to purge unmanaged configuration files in **/etc/unbound/unbound.conf.d** .
