### PR TITLE
Fix default value for edns_buffer_size

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,7 +14,7 @@ unbound::outgoing_port_avoid: '0-32767'
 unbound::outgoing_port_permit_first: true
 unbound::outgoing_num_tcp: ~
 unbound::incoming_num_tcp: ~
-unbound::edns_buffer_size: 1280
+unbound::edns_buffer_size: 4096
 unbound::max_udp_size: ~
 unbound::msg_buffer_size: ~
 unbound::msg_cache_size: ~


### PR DESCRIPTION
We should stick to the defaults:

```
       edns-buffer-size: <number>
              Number of bytes size to advertise as the EDNS reassembly  buffer
              size.   This  is  the  value put into datagrams over UDP towards
              peers.  The actual buffer size is determined by  msg-buffer-size
              (both  for  TCP  and  UDP).   Do not set higher than that value.
              Default is 4096 which is RFC recommended.  If you have  fragmen-
              tation  reassembly  problems,  usually  seen as timeouts, then a
              value of 1472 can fix it.  Setting to 512 bypasses even the most
              stringent  path  MTU problems, but is seen as extreme, since the
              amount of TCP fallback generated is excessive (probably also for
              this resolver, consider tuning the outgoing tcp number).
``