### PR TITLE
Fix on OS where root group != 'root'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -272,7 +272,7 @@ class unbound (
   file { $unbound_conf_d:
     ensure  => 'directory',
     owner   => 'root',
-    group   => 'root',
+    group   => '0',
     purge   => $purge_unbound_conf_d,
     recurse => $purge_unbound_conf_d,
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -72,7 +72,7 @@ describe 'unbound' do
           is_expected.to contain_file(unbound_conf_d).with(
             'ensure'  => 'directory',
             'owner'   => 'root',
-            'group'   => 'root',
+            'group'   => '0',
             'purge'   => false,
             'recurse' => false
           )


### PR DESCRIPTION
There are plenty of OS out there, where group root doesn't exist,
so use 0 instead to refer to the root users group, i.e. might
be group wheel

This is the case for me on OpenBSD, and my usual fix when I 
encounter a group named 'root'




<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
