### PR TITLE
Restart for interface change after service is configured

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -225,11 +225,13 @@ class unbound (
   if $control_enable {
     file {"${confdir}/interfaces.txt":
       ensure  => file,
-      notify  => Exec[$restart_cmd],
+      notify  => Exec['restart unbound'],
       content => template('unbound/interfaces.txt.erb'),
     }
-    exec {$restart_cmd:
+    exec { 'restart unbound':
+      command     => $restart_cmd,
       refreshonly => true,
+      require     => Service[$service_name],
     }
     Service[$service_name] {
       restart   => "${control_path} reload",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -865,13 +865,13 @@ describe 'unbound' do
         case facts[:osfamily]
         when 'FreeBSD'
           it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/local/sbin/unbound-control-setup -d /usr/local/etc/unbound') }
-          it { is_expected.to contain_exec('restart unbound').with_command('/usr/sbin/service restart unbound')}
+          it { is_expected.to contain_exec('restart unbound').with_command('/usr/sbin/service restart unbound') }
         when 'OpenBSD'
           it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/sbin/unbound-control-setup -d /var/unbound/etc') }
-          it { is_expected.to contain_exec('restart unbound').with_command('/usr/sbin/rcctl restart unbound')}
+          it { is_expected.to contain_exec('restart unbound').with_command('/usr/sbin/rcctl restart unbound') }
         else
           it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/sbin/unbound-control-setup -d /etc/unbound') }
-          it { is_expected.to contain_exec('restart unbound').with_command('/bin/systemctl restart unbound')}
+          it { is_expected.to contain_exec('restart unbound').with_command('/bin/systemctl restart unbound') }
         end
       end
 
@@ -900,23 +900,23 @@ describe 'unbound' do
             control_enable: true,
             interface: [
               '1.2.3.4',
-              '4.3.2.1',
+              '4.3.2.1'
             ],
-            restart_cmd: '/bin/false',
+            restart_cmd: '/bin/false'
           }
         end
 
         it {
-          is_expected.to contain_file('/etc/unbound/interfaces.txt')
-            .with_content('# Used by puppet-unbound')
-            .with_content(%r{^1.2.3.4$})
-            .with_content(%r{^4.3.2.1$})
-            .that_notifies('Exec[restart unbound]')
+          is_expected.to contain_file('/etc/unbound/interfaces.txt').
+            with_content('# Used by puppet-unbound').
+            with_content(%r{^1.2.3.4$}).
+            with_content(%r{^4.3.2.1$}).
+            that_notifies('Exec[restart unbound]')
         }
 
         it {
-          is_expected.to contain_exec('restart unbound')
-            .that_requires('Service[unbound]')
+          is_expected.to contain_exec('restart unbound').
+            that_requires('Service[unbound]')
         }
       end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -865,10 +865,13 @@ describe 'unbound' do
         case facts[:osfamily]
         when 'FreeBSD'
           it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/local/sbin/unbound-control-setup -d /usr/local/etc/unbound') }
+          it { is_expected.to contain_exec('restart unbound').with_command('/usr/sbin/service restart unbound')}
         when 'OpenBSD'
           it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/sbin/unbound-control-setup -d /var/unbound/etc') }
+          it { is_expected.to contain_exec('restart unbound').with_command('/usr/sbin/rcctl restart unbound')}
         else
           it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/sbin/unbound-control-setup -d /etc/unbound') }
+          it { is_expected.to contain_exec('restart unbound').with_command('/bin/systemctl restart unbound')}
         end
       end
 
@@ -889,6 +892,32 @@ describe 'unbound' do
         end
 
         it { is_expected.to contain_exec('unbound-control-setup').with_command('/no/bin/unbound-control-setup -d /var/nowhere/unbound') }
+      end
+
+      context 'control enablement with interfaces' do
+        let(:params) do
+          {
+            control_enable: true,
+            interface: [
+              '1.2.3.4',
+              '4.3.2.1',
+            ],
+            restart_cmd: '/bin/false',
+          }
+        end
+
+        it {
+          is_expected.to contain_file('/etc/unbound/interfaces.txt')
+            .with_content('# Used by puppet-unbound')
+            .with_content(%r{^1.2.3.4$})
+            .with_content(%r{^4.3.2.1$})
+            .that_notifies('Exec[restart unbound]')
+        }
+
+        it {
+          is_expected.to contain_exec('restart unbound')
+            .that_requires('Service[unbound]')
+        }
       end
 
       context 'custom interface selection' do


### PR DESCRIPTION
#### Pull Request (PR) description
When interfaces change, a restart is triggered. There is no ordering defined, so this can run before the configuration file, root keys, etc. are written - so the restart fails.

This PR solves this by adding some ordering to run the unbound restart command after the service resource has run - so anything which notifies or runs before the service resource will always run before the restart. This also means that the restart now runs *after* the service has started - so the initial config of the service means it will start and then restart. Given it's only the initial restart, I think that's ok.

I also change some titles for resources, to make testing easier - I have found that best practice is to define static titles for things like exec, and then make the command dynamic - so that they can be referenced easily in dependencies and specs.

I have been unable to run the specs - I have followed the instructions in the contributor guide, but it never seems to want to find any facts for the OSes. I am not at all familiar with the style of defining facts for tests in this module.
I did write tests - but am not sure if they are currently passing. The module works when run on real systems - I am using this.

#### This Pull Request (PR) fixes the following issues
Issue described above - happy to submit an issue if that is required for a PR.