### PR TITLE
Single quote TXT records and break them into strings of 255 characters

### DIFF
--- a/spec/defines/localzone_spec.rb
+++ b/spec/defines/localzone_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe 'unbound::localzone' do
+  let(:title) { 'example.com' }
+  let(:pre_condition) { 'class { "unbound": }' }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with a TXT record (<255 characters)' do
+        let(:params) do
+          {
+            type: 'transparent',
+            local_data: [
+              {
+                name: 'txt.example.com',
+                type: 'TXT',
+                data: 'Short TXT Record'
+              }
+            ]
+          }
+        end
+
+        it { is_expected.to contain_unbound__localzone('example.com') }
+        it {
+          is_expected.to contain_concat__fragment('unbound-localzone-example.com').with(
+            content: [
+              'server:',
+              '  local-zone: "example.com" transparent',
+              '  local-data: \'txt.example.com TXT "Short TXT Record"\''
+            ].join("\n") + "\n"
+          )
+        }
+      end
+
+      context 'with a TXT record (>255 characters)' do
+        long_txt_record = 'Long TXT Record ' + 'X' * 255
+        long_txt_record_chunked = 'Long TXT Record ' + 'X' * 239 + '""' + 'X' * 16
+        let(:params) do
+          {
+            type: 'transparent',
+            local_data: [
+              {
+                name: 'txt.example.com',
+                type: 'TXT',
+                data: long_txt_record
+              }
+            ]
+          }
+        end
+
+        it { is_expected.to contain_unbound__localzone('example.com') }
+        it {
+          is_expected.to contain_concat__fragment('unbound-localzone-example.com').with(
+            content: [
+              'server:',
+              '  local-zone: "example.com" transparent',
+              "  local-data: 'txt.example.com TXT \"#{long_txt_record_chunked}\"'"
+            ].join("\n") + "\n"
+          )
+        }
+      end
+    end
+  end
+end

--- a/spec/defines/record_spec.rb
+++ b/spec/defines/record_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'unbound::record' do
+  let(:title) { 'record.example.com' }
+  let(:pre_condition) { 'class { "unbound": }' }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with a TXT record (<255 characters)' do
+        let(:params) do
+          {
+            type: 'TXT',
+            content: 'Short TXT Record',
+            reverse: false
+          }
+        end
+
+        it { is_expected.to contain_unbound__record('record.example.com') }
+        it {
+          is_expected.to contain_concat__fragment('unbound-stub-record.example.com-local-record').with(
+            content: "  local-data: 'record.example.com 14400 IN TXT \"Short TXT Record\"'\n"
+          )
+        }
+      end
+
+      context 'with a TXT record (>255 characters)' do
+        long_txt_record = 'Long TXT Record ' + 'X' * 255
+        long_txt_record_chunked = 'Long TXT Record ' + 'X' * 239 + '""' + 'X' * 16
+        let(:params) do
+          {
+            type: 'TXT',
+            content: long_txt_record,
+            reverse: false
+          }
+        end
+
+        it { is_expected.to contain_unbound__record('record.example.com') }
+        it {
+          is_expected.to contain_concat__fragment('unbound-stub-record.example.com-local-record').with(
+            content: "  local-data: 'record.example.com 14400 IN TXT \"#{long_txt_record_chunked}\"'\n"
+          )
+        }
+      end
+    end
+  end
+end

--- a/templates/local_zone.erb
+++ b/templates/local_zone.erb
@@ -5,6 +5,11 @@ server:
     <%- rr = "#{rr} #{resource_record['ttl']}" if resource_record['ttl'] -%>
     <%- rr = "#{rr} #{resource_record['class']}" if resource_record['class'] -%>
     <%- rr = "#{rr} #{resource_record['type']}" -%>
-    <%- rr = "#{rr} #{resource_record['data']}" -%>
+    <%- if resource_record['type'] != 'TXT' -%>
+      <%- rr = "#{rr} #{resource_record['data']}" -%>
   local-data: "<%= rr %>"
+    <%- else -%>
+      <%- rr = "#{rr} #{(resource_record['data'].scan /.{1,255}/).inject(''){|r, s| "#{r}\"#{s}\""}}" -%>
+  local-data: '<%= rr %>'
+    <%- end -%>
   <%- end -%>


### PR DESCRIPTION
The unbound documentation for local-data directives advise the usage of single quotes for TXT records to handle white space et double quotes.
This pull request implements this for `unbound::records` and `unbound::local_zone`.
TXT records will also be automatically broken into 255 characters strings as per RFC 4408.

Then you can declare DKIM records, for example, like this:
```
  unbound::record {
    'mail._domainkey.example.org':
      type    => 'TXT',
      content => 'v=DKIM1; h=sha256; k=rsa; p=DKIM_KEY_LONG_STRING_1DKIM_KEY_LONG_STRING_2',
  }
```
This will generate:
```
local-data: 'mail._domainkey.example.org 14400 IN TXT "v=DKIM1; h=sha256; k=rsa; p=DKIM_KEY_LONG_STRING_1""DKIM_KEY_LONG_STRING_2"'
```

Fixes #237