### PR TITLE
Add support for stub-no-cache option

### DIFF
--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -32,6 +32,7 @@ define unbound::stub (
   Variant[Array[Unbound::Address], Unbound::Address] $address,
   # lint:ignore:quoted_booleans
   Variant[Boolean, Enum['true', 'false']]            $insecure    = false,
+  Variant[Boolean, Enum['true', 'false']]            $no_cache    = false,
   # lint:endignore
   Unbound::Local_zone_type                           $type        = 'transparent',
   Stdlib::Unixpath                                   $config_file = lookup('unbound::config_file'),

--- a/spec/defines/stub_spec.rb
+++ b/spec/defines/stub_spec.rb
@@ -7,14 +7,45 @@ describe 'unbound::stub' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      let(:params) do
-        {
-          address: ['::1']
+      context 'basic' do
+        let(:params) do
+          {
+            address: ['::1']
+          }
+        end
+
+        it { is_expected.to contain_unbound__stub('lab.example.com') }
+        it {
+          is_expected.to contain_concat__fragment('unbound-stub-lab.example.com').with(
+            content: [
+              'stub-zone:',
+              '  name: "lab.example.com"',
+              '  stub-addr: ::1'
+            ].join("\n") + "\n"
+          )
         }
       end
 
-      it { is_expected.to contain_unbound__stub('lab.example.com') }
-      it { is_expected.to contain_concat__fragment('unbound-stub-lab.example.com') }
+      context 'with no_cache set' do
+        let(:params) do
+          {
+            address: ['::1'],
+            no_cache: true
+          }
+        end
+
+        it { is_expected.to contain_unbound__stub('lab.example.com') }
+        it {
+          is_expected.to contain_concat__fragment('unbound-stub-lab.example.com').with(
+            content: [
+              'stub-zone:',
+              '  name: "lab.example.com"',
+              '  stub-addr: ::1',
+              '  stub-no-cache: yes'
+            ].join("\n") + "\n"
+          )
+        }
+      end
     end
   end
 end

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -3,3 +3,6 @@ stub-zone:
 <% @address.each do |addr| -%>
   stub-addr: <%= addr %>
 <% end -%>
+<% if @no_cache == 'true' or @no_cache == true -%>
+  stub-no-cache: yes
+<% end -%>


### PR DESCRIPTION
Without this change, users are unable to modify the default stub option for
disabling the cache.  Here we include support for the option and a test.