### PR TITLE
Fix erb template to allow string for address attribute

### DIFF
--- a/spec/defines/stub_spec.rb
+++ b/spec/defines/stub_spec.rb
@@ -14,6 +14,7 @@ describe 'unbound::stub' do
           }
         end
 
+        it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_unbound__stub('lab.example.com') }
         it {
           is_expected.to contain_concat__fragment('unbound-stub-lab.example.com').with(
@@ -34,6 +35,29 @@ describe 'unbound::stub' do
           }
         end
 
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_unbound__stub('lab.example.com') }
+        it {
+          is_expected.to contain_concat__fragment('unbound-stub-lab.example.com').with(
+            content: [
+              'stub-zone:',
+              '  name: "lab.example.com"',
+              '  stub-addr: ::1',
+              '  stub-no-cache: yes'
+            ].join("\n") + "\n"
+          )
+        }
+      end
+
+      context 'with address set as string' do
+        let(:params) do
+          {
+            address: '::1',
+            no_cache: true
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_unbound__stub('lab.example.com') }
         it {
           is_expected.to contain_concat__fragment('unbound-stub-lab.example.com').with(

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -1,6 +1,6 @@
 stub-zone:
   name: "<%= @name %>"
-<% @address.each do |addr| -%>
+<% [@address].flatten.each do |addr| -%>
   stub-addr: <%= addr %>
 <% end -%>
 <% if @no_cache == 'true' or @no_cache == true -%>


### PR DESCRIPTION
the attribute has a type that already allows an array and strings to be passed, but
the erb templates assumes an array is passed. this patch fixes this.
Alos there were some typos in the existing tests that disabled most of
them. That's fixed as well.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
