### PR TITLE
Disable Debian 8 acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,7 +5,6 @@
     - set: centos6-64
     - set: centos7-64
     - set: centos8-64
-    - set: debian8-64
     - set: debian9-64
     - set: debian10-64
     - set: ubuntu1604-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,6 @@ jobs:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=debian8-64 CHECK=beaker
-    services: docker
-  - rvm: 2.5.3
-    bundler_args: --without development release
-    env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=debian8-64 CHECK=beaker
-    services: docker
-  - rvm: 2.5.3
-    bundler_args: --without development release
     env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=debian9-64 CHECK=beaker
     services: docker
   - rvm: 2.5.3


### PR DESCRIPTION
We already dropped the debian 8 code in https://github.com/voxpupuli/puppet-unbound/pull/246