### PR TITLE
Drop RedHat 6 (and derivatives) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,6 @@ jobs:
       env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
     - rvm: 2.5.3
       bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
       env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos7-64 CHECK=beaker
       services: docker
     - rvm: 2.5.3

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -19,7 +18,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -27,7 +25,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -35,7 +32,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -869,13 +869,6 @@ describe 'unbound' do
         when 'OpenBSD'
           it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/sbin/unbound-control-setup -d /var/unbound/etc') }
           it { is_expected.to contain_exec('restart unbound').with_command('/usr/sbin/rcctl restart unbound') }
-        when 'RedHat'
-          if facts[:os]['release']['major'].to_i == 6
-            it { is_expected.to contain_exec('restart unbound').with_command('/usr/bin/service unbound restart') }
-          else
-            it { is_expected.to contain_exec('restart unbound').with_command('/bin/systemctl restart unbound') }
-          end
-          it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/sbin/unbound-control-setup -d /etc/unbound') }
         else
           it { is_expected.to contain_exec('unbound-control-setup').with_command('/usr/sbin/unbound-control-setup -d /etc/unbound') }
           it { is_expected.to contain_exec('restart unbound').with_command('/bin/systemctl restart unbound') }


### PR DESCRIPTION
The module will likely still work however maintaining the work around
in the spec tests is a pain

