### PR TITLE
custom_server_conf order

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -288,10 +288,10 @@ class unbound (
     target  => $config_file,
     content => template('unbound/unbound.conf.erb'),
   }
-  concat::fragment { 'unbound-custom':
+  concat::fragment { 'unbound_custom':
     order   => '08',
     target  => $config_file,
-    content => template('unbound/unbound-custom.conf.erb'),
+    content => template('unbound/unbound_custom.conf.erb'),
   }
   concat::fragment { 'unbound-modules':
     order   => '09',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -288,6 +288,11 @@ class unbound (
     target  => $config_file,
     content => template('unbound/unbound.conf.erb'),
   }
+  concat::fragment { 'unbound-custom':
+    order   => '08',
+    target  => $config_file,
+    content => template('unbound/unbound-custom.conf.erb'),
+  }
   concat::fragment { 'unbound-modules':
     order   => '09',
     target  => $config_file,

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -219,6 +219,3 @@ server:
 <%= print_config('ip-ratelimit-size', @ip_ratelimit_size, '1.6.1') -%>
 <%= print_config('ip-ratelimit-slabs', @ip_ratelimit_slabs, '1.6.1') -%>
 <%= print_config('ip-ratelimit-factor', @ip_ratelimit_factor, '1.6.1') -%>
-<% @custom_server_conf.each do |c| -%>
-  <%= c %>
-<% end -%>

--- a/templates/unbound.modules.conf.erb
+++ b/templates/unbound.modules.conf.erb
@@ -1,5 +1,3 @@
-# Managed by Puppet
-#
 <%-
   def unbound_version
     version = @unbound_version ? @unbound_version : '0.a'

--- a/templates/unbound_custom.conf.erb
+++ b/templates/unbound_custom.conf.erb
@@ -1,0 +1,3 @@
+<% @custom_server_conf.each do |c| -%>
+  <%= c %>
+<% end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Change the order on which the custom_server_conf is included into the unbound.conf.erb . In some cases the custom_server_config could need to be after the stub zones data that is concat into the unbound.conf. 
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
