### PR TITLE
Provide root-hints variables & overrides for different scenarios

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -74,7 +74,6 @@ unbound::log_tag_queryreply: false
 unbound::log_local_actions: false
 unbound::log_servfail: false
 unbound::pidfile: '/var/run/unbound/unbound.pid'
-unbound::hints_file: "%{hiera('unbound::confdir')}/root.hints"
 unbound::hide_identity: true
 unbound::identity: ~
 unbound::hide_version: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,8 @@
 #
 # Installs and configures Unbound, the caching DNS resolver from NLnet Labs
 #
+# @param hints_file
+#   File path to the root-hints. Type[Undef] to remove root hints reference from unbound.conf
 # @param manage_roothints_file
 #   Toggle for if the module should manage the root hints file. Useful if file is managed elsewhere.
 # @param hints_file_content
@@ -81,7 +83,6 @@ class unbound (
   Boolean                                              $log_local_actions,            # version 1.8.0
   Boolean                                              $log_servfail,                 # version 1.8.0
   Optional[Stdlib::Absolutepath]                       $pidfile,
-  Stdlib::Absolutepath                                 $hints_file,
   Boolean                                              $hide_identity,
   Optional[String]                                     $identity,
   Boolean                                              $hide_version,
@@ -209,6 +210,7 @@ class unbound (
   Integer[1,65536]                                     $redis_server_port,
   Integer[1]                                           $redis_timeout,
   Stdlib::Absolutepath                                 $unbound_conf_d,
+  Optional[Stdlib::Absolutepath]                       $hints_file            = "${confdir}/root.hints",
   Optional[String[1]]                                  $hints_file_content    = undef,
   Boolean                                              $manage_roothints_file = true,
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,7 +209,7 @@ class unbound (
   Integer[1,65536]                                     $redis_server_port,
   Integer[1]                                           $redis_timeout,
   Stdlib::Absolutepath                                 $unbound_conf_d,
-  Optional[String[1]]                                  $hints_file_content
+  Optional[String[1]]                                  $hints_file_content    = undef,
   Boolean                                              $manage_roothints_file = true,
 ) {
   unless $package_name.empty {
@@ -224,7 +224,9 @@ class unbound (
     Package[$package_name] -> File[$keys_d]
     Package[$package_name] -> File[$runtime_dir]
     Package[$package_name] -> Exec['download-roothints']
-    Package[$package_name] -> File[$hints_file]
+    if $manage_roothints_file {
+      Package[$package_name] -> File[$hints_file]
+    }
   }
 
   $_base_dirs = [$confdir, $conf_d, $keys_d, $runtime_dir]
@@ -304,7 +306,7 @@ class unbound (
     file { $hints_file:
       ensure => file,
       mode   => '0444',
-      *      => $_hints_file_content
+      *      => $_hints_file_content,
     }
   }
 

--- a/spec/classes/expected/hieradata-root-hint.conf
+++ b/spec/classes/expected/hieradata-root-hint.conf
@@ -1,0 +1,3 @@
+test
+root
+hints

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -953,6 +953,20 @@ describe 'unbound' do
         it { is_expected.not_to contain_file(hints_file) }
       end
 
+      context 'no root hints' do
+        let(:params) do
+          {
+            hints_file: :undef
+          }
+        end
+
+        it do 
+          is_expected.to contain_concat__fragment(
+            'unbound-header'
+          ).without_content('root-hints:')
+        end
+      end
+
       context 'hieradata root hints' do
         let(:params) do
           {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -943,20 +943,10 @@ describe 'unbound' do
         end
       end
 
-      context 'unmanaged root hints' do
-        let(:params) do
-          {
-            create_root_hints: false
-          }
-        end
-
-        it { is_expected.not_to contain_file(hints_file) }
-      end
-
       context 'no root hints in config' do
         let(:params) do
           {
-            root_hints_in_config: false
+            hints_file: 'builtin'
           }
         end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -963,7 +963,7 @@ describe 'unbound' do
         it do 
           is_expected.to contain_concat__fragment(
             'unbound-header'
-          ).without_content('root-hints:')
+          ).without_content(%r{root-hints})
         end
       end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -946,17 +946,17 @@ describe 'unbound' do
       context 'unmanaged root hints' do
         let(:params) do
           {
-            manage_roothints_file: false
+            create_root_hints: false
           }
         end
 
         it { is_expected.not_to contain_file(hints_file) }
       end
 
-      context 'no root hints' do
+      context 'no root hints in config' do
         let(:params) do
           {
-            hints_file: :undef
+            root_hints_in_config: false
           }
         end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -943,6 +943,33 @@ describe 'unbound' do
         end
       end
 
+      context 'unmanaged root hints' do
+        let(:params) do
+          {
+            manage_roothints_file: false
+          }
+        end
+
+        it { is_expected.not_to contain_file(hints_file) }
+      end
+
+      context 'hieradata root hints' do
+        let(:params) do
+          {
+            skip_roothints_download: true,
+            hints_file_content: File.read('spec/classes/expected/hieradata-root-hint.conf'),
+          }
+        end
+        
+        it do
+          is_expected.to contain_file(hints_file).with(
+            'ensure'  => 'file',
+            'mode'    => '0444',
+            'content' => File.read('spec/classes/expected/hieradata-root-hint.conf'),
+          )
+        end
+      end
+
       context 'with File defaults' do
         let(:pre_condition) { "File { mode => '0644', owner => 'root', group => 'root' }" }
 

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -140,7 +140,7 @@ server:
 <%= print_config('log-servfail', @log_servfail, '1.8.0') -%>
 <%= print_config('hide-identity', @hide_identity) -%>
 <%= print_config('pidfile', @pidfile) -%>
-<%- if @root_hints_in_config %>
+<%- unless @hints_file == 'builtin' -%>
 <%= print_config('root-hints', @hints_file) -%>
 <%- end -%>
 <%= print_config('identity', @identity) -%>

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -140,7 +140,7 @@ server:
 <%= print_config('log-servfail', @log_servfail, '1.8.0') -%>
 <%= print_config('hide-identity', @hide_identity) -%>
 <%= print_config('pidfile', @pidfile) -%>
-<%- if @hints_file %>
+<%- if @root_hints_in_config %>
 <%= print_config('root-hints', @hints_file) -%>
 <%- end -%>
 <%= print_config('identity', @identity) -%>

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -140,7 +140,9 @@ server:
 <%= print_config('log-servfail', @log_servfail, '1.8.0') -%>
 <%= print_config('hide-identity', @hide_identity) -%>
 <%= print_config('pidfile', @pidfile) -%>
+<%- if @manage_roothints_file %>
 <%= print_config('root-hints', @hints_file) -%>
+<%- end -%>
 <%= print_config('identity', @identity) -%>
 <%= print_config('hide-version', @hide_version) -%>
 <%= print_config('version', @version) -%>

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -140,7 +140,7 @@ server:
 <%= print_config('log-servfail', @log_servfail, '1.8.0') -%>
 <%= print_config('hide-identity', @hide_identity) -%>
 <%= print_config('pidfile', @pidfile) -%>
-<%- if @manage_roothints_file %>
+<%- if @hints_file %>
 <%= print_config('root-hints', @hints_file) -%>
 <%- end -%>
 <%= print_config('identity', @identity) -%>


### PR DESCRIPTION
#### Pull Request (PR) description

This PR creates a toggle for the root-hints file resource, so that it can be optionally disabled. In addition, the contents of root-hints can be overridden using either hieradata or a class-parameter override, in instances where the root hints content isn't remotely fetchable. 

#### This Pull Request (PR) fixes the following issues

Allows the root hint file to be optionally managed. There are instances where this file may not be used, or created outside of this module, so in this cases the module shouldn't have a file resource managing it. Furthermore, there may be situations where the contents of this root-hints file isn't available via a remote system and it's necessary to have the contents of that file passed through hieradata or a class-parameter override.