### PR TITLE
Adjustment for DNS Flag Day 2020

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class unbound (
   Boolean                                       $outgoing_port_permit_first      = true,
   Optional[Integer[0]]                          $outgoing_num_tcp                = undef,
   Optional[Integer[0]]                          $incoming_num_tcp                = undef,
-  Integer[0,4096]                               $edns_buffer_size                = 1280,
+  Integer[0,4096]                               $edns_buffer_size                = 1232,
   Optional[Integer[0,65536]]                    $max_udp_size                    = undef,
   Optional[Unbound::Size]                       $stream_wait_size                = undef,  # version 1.9.0
   Optional[Unbound::Size]                       $msg_cache_size                  = undef,


### PR DESCRIPTION
#### Pull Request (PR) description
Adjust default edns_buffer_size to 1232 as per recommendation for DNS Flag Day 2020

https://dnsflagday.net/2020/
https://nlnetlabs.nl/documentation/unbound/unbound.conf/#edns-buffer-size