### PR TITLE
'target-fetch-policy' is supposed to be a single string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@ class unbound (
   Boolean                                       $hide_version                    = true,
   Optional[String[1]]                           $version                         = undef,
   Boolean                                       $hide_trustanchor                = true,   # version 1.6.2
-  String                                        $target_fetch_policy             = '3 2 1 0 0',
+  Array[Integer]                                $target_fetch_policy             = [],
   Boolean                                       $harden_short_bufsize            = false,
   Boolean                                       $harden_large_queries            = false,
   Boolean                                       $harden_glue                     = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@ class unbound (
   Boolean                                       $hide_version                    = true,
   Optional[String[1]]                           $version                         = undef,
   Boolean                                       $hide_trustanchor                = true,   # version 1.6.2
-  Array[Integer]                                $target_fetch_policy             = [],
+  String                                        $target_fetch_policy             = '3 2 1 0 0',
   Boolean                                       $harden_short_bufsize            = false,
   Boolean                                       $harden_large_queries            = false,
   Boolean                                       $harden_glue                     = true,

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -147,7 +147,7 @@ server:
 <%= print_config('hide-version', @hide_version) -%>
 <%= print_config('version', @version) -%>
 <%= print_config('hide-trustanchor', @hide_trustanchor, '1.6.2') -%>
-<%= print_config('target-fetch-policy', @target_fetch_policy) -%>
+<%= print_config('target-fetch-policy', "#{@target_fetch_policy}") -%>
 <%= print_config('harden-short-bufsize', @harden_short_bufsize) -%>
 <%= print_config('harden-large-queries', @harden_large_queries) -%>
 <%= print_config('harden-glue', @harden_glue) -%>

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -147,7 +147,9 @@ server:
 <%= print_config('hide-version', @hide_version) -%>
 <%= print_config('version', @version) -%>
 <%= print_config('hide-trustanchor', @hide_trustanchor, '1.6.2') -%>
-<%= print_config('target-fetch-policy', "#{@target_fetch_policy.join(' ')}") -%>
+<%- unless @target_fetch_policy.empty? -%>
+<%= print_config('target-fetch-policy', @target_fetch_policy.join(' ')) -%>
+<%- end -%>
 <%= print_config('harden-short-bufsize', @harden_short_bufsize) -%>
 <%= print_config('harden-large-queries', @harden_large_queries) -%>
 <%= print_config('harden-glue', @harden_glue) -%>

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -147,7 +147,7 @@ server:
 <%= print_config('hide-version', @hide_version) -%>
 <%= print_config('version', @version) -%>
 <%= print_config('hide-trustanchor', @hide_trustanchor, '1.6.2') -%>
-<%= print_config('target-fetch-policy', "#{@target_fetch_policy}") -%>
+<%= print_config('target-fetch-policy', "#{@target_fetch_policy.join(' ')}") -%>
 <%= print_config('harden-short-bufsize', @harden_short_bufsize) -%>
 <%= print_config('harden-large-queries', @harden_large_queries) -%>
 <%= print_config('harden-glue', @harden_glue) -%>


### PR DESCRIPTION
From unbound documentation:

```
       target-fetch-policy: <"list of numbers">
              Set  the  target fetch policy used by unbound to determine if it
              should fetch nameserver target addresses opportunistically.  The
              policy is described per dependency depth.

              The  number  of  values  determines the maximum dependency depth
              that unbound will pursue in answering a query.  A  value  of  -1
              means to fetch all targets opportunistically for that dependency
              depth. A value of 0 means to fetch on demand  only.  A  positive
              value fetches that many targets opportunistically.

              Enclose the list between quotes ("") and put spaces between num-
              bers.  The default is "3 2 1 0 0". Setting all zeroes, "0 0 0  0
              0"  gives  behaviour closer to that of BIND 9, while setting "-1
              -1 -1 -1 -1" gives behaviour rumoured to be closer  to  that  of
              BIND 8.
```

Current code creates configuration with undefined behaviour.