### PR TITLE
fix typo in template: includes? -> include? / make access_control parameter useable

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -118,6 +118,42 @@ describe 'unbound' do
         end
       end
 
+      context 'with access control configured' do
+        let(:facts) { facts.merge(unbound_version: '1.6.1') }
+        let :params do
+          {
+            access_control: {
+              'foobar' => {
+                'view' => 'allow'
+              },
+              'foobaz' => {
+                'action' => 'allow',
+                'rr_string' => '::/0',
+                'tags' => %w[123 456]
+              }
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it {
+          expect(subject).to contain_concat__fragment(
+            'unbound-header'
+          ).with_content(
+            %r{\s+access-control-view: foobar}
+          ).with_content(
+            %r{\s+access-control-tag-action: foobaz 123 allow}
+          ).with_content(
+            %r{\s+access-control-tag-action: foobaz 123 ::/0}
+          ).with_content(
+            %r{\s+access-control-tag-action: foobaz 456 allow}
+          ).with_content(
+            %r{\s+access-control-tag-action: foobaz 456 ::/0}
+          )
+        }
+      end
+
       context 'module config' do
         context 'dns64' do
           before { params.merge!(module_config: %w[dns64]) }

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -103,7 +103,7 @@ server:
 <%- end -%>
 <%- if scope.call_function('versioncmp', [unbound_version, '1.5.10']) >= 0 -%>
   <%- @access_control.each_pair do |prefix, config| -%>
-    <%- if config.includes?('tags') -%>
+    <%- if config.include?('tags') -%>
       <%- unless config.include?('action') or config.include?('rr_string') -%>
   access-control-tag: <%= prefix %> "<%= tags.join(' ') %>"
       <%- else -%>
@@ -117,7 +117,7 @@ server:
         <%- end -%>
       <%- end -%>
     <%- end -%>
-    <%- if config.includes?('view') -%>
+    <%- if config.include?('view') -%>
   access-control-view: <%= prefix %> <% config['view'] %>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
fixes two typos in the erb template. The typos prevented the usage of the access_control parameter. This is now fixed an verified with unittests.