### PR TITLE
(297) Add support for stub nameservers and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,16 +84,18 @@ unbound::stub { "0.0.10.in-addr.arpa.":
   insecure => true,
 }
 
-# address can be an array.
+# address can be an array along with nameservers.
 # in the following case, generated conf would be as follows:
 #
-#   stub-host: ns1.example.com
+#   stub-addr: 10.0.0.53
 #   stub-addr: 10.0.0.10@10053
+#   stub-host: ns1.example.com
 #   stub-host: ns2.example.com
 #
 # note that conf will be generated in the same order provided.
 unbound::stub { "10.0.10.in-addr.arpa.":
-  address => [ 'ns1.example.com', '10.0.0.10@10053', 'ns2.example.com' ],
+  address    => [ 10.0.0.53', '10.0.0.10@10053'],
+  namservers => [ 'ns1.example.com', 'ns2.example.com' ],
 }
 ```
 
@@ -103,8 +105,10 @@ Or, using hiera
 unbound::stub:
   '10.0.10.in-addr.arpa.':
     address:
-      - 'ns1.example.com'
+      - '10.0.0.53
       - '10.0.0.10@10053'
+    nameserveres:
+      - 'ns1.example.com'
       - 'ns2.example.com'
 ```
 

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -9,6 +9,9 @@
 #   array or a single value. To use a nondefault port for DNS communication
 #   append  '@' with the port number.
 #
+# [*nameservers*]
+#   (optional) Name of stub zone nameserver. Is itself resolved before it is used.
+#
 # [*insecure*]
 #   (optional) Defaults to false. Sets domain name to be insecure, DNSSEC chain
 #   of trust is ignored towards the domain name.  So a trust anchor  above the
@@ -30,6 +33,7 @@
 #
 define unbound::stub (
   Variant[Array[Unbound::Address], Unbound::Address] $address,
+  Array[Stdlib::Host]                                 $nameservers = [],
   # lint:ignore:quoted_booleans
   Variant[Boolean, Enum['true', 'false']]            $insecure    = false,
   Variant[Boolean, Enum['true', 'false']]            $no_cache    = false,

--- a/spec/defines/stub_spec.rb
+++ b/spec/defines/stub_spec.rb
@@ -30,6 +30,30 @@ describe 'unbound::stub' do
         }
       end
 
+      context 'unbound::address' do
+        let(:params) do
+          {
+            address: '10.0.0.10@10053',
+            nameservers: ['ns1.example.com', 'ns2.example.com'],
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_unbound__stub('lab.example.com') }
+
+        it {
+          expect(subject).to contain_concat__fragment('unbound-stub-lab.example.com').with(
+            content: <<~ZONE
+              stub-zone:
+                name: "lab.example.com"
+                stub-addr: 10.0.0.10@10053
+                stub-host: ns1.example.com
+                stub-host: ns2.example.com
+            ZONE
+          )
+        }
+      end
+
       context 'with no_cache set' do
         let(:params) do
           {

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -3,6 +3,9 @@ stub-zone:
 <% [@address].flatten.each do |addr| -%>
   stub-addr: <%= addr %>
 <% end -%>
+<% @nameservers.each do |host| -%>
+  stub-host: <%= host %>
+<% end -%>
 <% if @no_cache == 'true' or @no_cache == true -%>
   stub-no-cache: yes
 <% end -%>


### PR DESCRIPTION
and a new parameter to unbound::stub to support `stub-host`

fixes #297