### PR TITLE
Drop centos support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -243,8 +243,6 @@ The following strings are known to work:
 * ubuntu2004
 * debian9
 * debian10
-* centos7
-* centos8
 
 For more information and tips & tricks, see [voxpupuli-acceptance's documentation](https://github.com/voxpupuli/voxpupuli-acceptance#running-tests).
 

--- a/metadata.json
+++ b/metadata.json
@@ -16,13 +16,6 @@
       ]
     },
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",


### PR DESCRIPTION
CI is currently broken for all centos builds so we should drop it

See: https://github.com/voxpupuli/puppet-unbound/pull/295