### PR TITLE
296: Add support for multiple contents/records in unbound::record

### DIFF
--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -23,28 +23,30 @@
 #   (optional) name of configuration file
 #
 define unbound::record (
-  String $content,
+  Variant[Array[String[1]], String[1]] $content,
   $ttl         = '14400',
   $type        = 'A',
   $reverse     = false,
   $entry       = $name,
   $config_file = $unbound::config_file,
 ) {
-  if $type != 'TXT' {
-    $local_data     = "  local-data: \"${entry} ${ttl} IN ${type} ${content}\"\n"
-  } else {
-    # Long TXT records must be broken into strings of 255 characters as per RFC 4408
-    $real_content = $content.slice(255)
-    .reduce('') |String $record, Array $s| {
-      "${record}\"${s.join()}\""
+  $local_data = [$content].flatten.map |$_content| {
+    if $type != 'TXT' {
+      "  local-data: \"${entry} ${ttl} IN ${type} ${_content}\""
+    } else {
+      # Long TXT records must be broken into strings of 255 characters as per RFC 4408
+      $real_content = $_content.slice(255)
+      .reduce('') |String $record, Array $s| {
+        "${record}\"${s.join()}\""
+      }
+      "  local-data: '${entry} ${ttl} IN ${type} ${real_content}'"
     }
-    $local_data     = "  local-data: '${entry} ${ttl} IN ${type} ${real_content}'\n"
-  }
-  $local_data_ptr = "  local-data-ptr: \"${content} ${entry}\"\n"
+  }.join("\n")
+  $local_data_ptr = "  local-data-ptr: \"${content} ${entry}\""
 
-  $config = $reverse? {
-    true    => "${local_data}${local_data_ptr}",
-    default => $local_data,
+  $config = $reverse ? {
+    true    => "${local_data}\n${local_data_ptr}\n",
+    default => "${local_data}\n",
   }
 
   concat::fragment { "unbound-stub-${title}-local-record":

--- a/spec/defines/record_spec.rb
+++ b/spec/defines/record_spec.rb
@@ -47,6 +47,27 @@ describe 'unbound::record' do
           )
         }
       end
+
+      context 'Multiple contents (answers)' do
+        let(:params) do
+          {
+            content: ['192.0.2.53', '192.0.2.42'],
+            reverse: false,
+          }
+        end
+
+        it { is_expected.to contain_unbound__record('record.example.com') }
+
+        it do
+          is_expected.to contain_concat__fragment('unbound-stub-record.example.com-local-record').
+            with_content(
+              %r{
+                  \s+local-data:\s"record.example.com\s14400\sIN\sA\s192.0.2.53"
+                  \s+local-data:\s"record.example.com\s14400\sIN\sA\s192.0.2.42"
+                }x
+            )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Allow users to provide and array of contents to allow a records to
resolve to multiple answers e.g.

  foo in A 192.0.2.53
  foo in A 192.0.2.42

fixes: #296