### PR TITLE
Introduce unbound_version parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,8 @@
 #   File path to the root-hints. Set to 'builtin' to remove root-hint option from unbound.conf and use built-in hints.
 # @param hints_file_content
 #   Contents of the root hints file, if it's not remotely fetched.
+# @param unbound_version
+#   the version of the installed unbound instance. defaults to the fact, but you can overwrite it. this reduces the initial puppet runs from two to one
 class unbound (
   Boolean                                       $manage_service                  = true,
   Integer[0,5]                                  $verbosity                       = 1,
@@ -212,6 +214,7 @@ class unbound (
   Unbound::Hints_file                           $hints_file                      = "${confdir}/root.hints",
   Optional[String[1]]                           $hints_file_content              = undef,
   Hash[String[1], Unbound::Rpz]                 $rpzs                            = {},
+  Optional[String[1]]                           $unbound_version                 = $facts['unbound_version'],
 ) {
   $_base_dirs = [$confdir, $conf_d, $keys_d, $runtime_dir]
   $_piddir = if $pidfile { dirname($pidfile) } else { undef }

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -2,8 +2,7 @@
 #
 <%-
   def unbound_version
-    version = @unbound_version ? @unbound_version : '0.a'
-    return version
+    @unbound_version ? @unbound_version : '0.a'
   end
   def print_config(name, value, version=false )
     if version and scope.call_function('versioncmp', [unbound_version, version]) < 0

--- a/templates/unbound.modules.conf.erb
+++ b/templates/unbound.modules.conf.erb
@@ -2,8 +2,7 @@
 #
 <%-
   def unbound_version
-    version = @unbound_version ? @unbound_version : '0.a'
-    return version
+    @unbound_version ? @unbound_version : '0.a'
   end
   def print_config(name, value, version=false )
     if version and scope.call_function('versioncmp', [unbound_version, version]) < 0


### PR DESCRIPTION
The version of the installed unbound instance. Defaults to the fact, but
you can overwrite it. this reduces the initial puppet runs from two to
one (because currently during the first run, the version is an empty
string and it defaults to `0a`. The module hides unbound.conf options
that are introduced in later versions.