### PR TITLE
stub: add support for stub-first stub zone option

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2359,6 +2359,11 @@ Create an unbound stub zone for caching upstream name resolvers
   lookups does not affect an (unsigned) internal domain.  A DS record
   externally can create validation failures for that internal domain.
 
+[*stub_first*]
+  (optional) Defaults to false. Controls 'stub-first' stub zone option.
+  If true, a query that fails with the stub clause is attempted again
+  without the stub clause.
+
 [*type*]
   (optional) Defaults to 'transparent', can be 'deny', 'refuse', 'static',
   'transparent', 'typetransparent', 'redirect' or 'nodefault'.
@@ -2374,6 +2379,7 @@ The following parameters are available in the `unbound::stub` defined type:
 * [`nameservers`](#-unbound--stub--nameservers)
 * [`insecure`](#-unbound--stub--insecure)
 * [`no_cache`](#-unbound--stub--no_cache)
+* [`stub_first`](#-unbound--stub--stub_first)
 * [`type`](#-unbound--stub--type)
 * [`config_file`](#-unbound--stub--config_file)
 
@@ -2400,6 +2406,14 @@ Data type: `Variant[Boolean, Enum['true', 'false']]`
 Default value: `false`
 
 ##### <a name="-unbound--stub--no_cache"></a>`no_cache`
+
+Data type: `Variant[Boolean, Enum['true', 'false']]`
+
+
+
+Default value: `false`
+
+##### <a name="-unbound--stub--stub_first"></a>`stub_first`
 
 Data type: `Variant[Boolean, Enum['true', 'false']]`
 

--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -24,6 +24,11 @@
 #   lookups does not affect an (unsigned) internal domain.  A DS record
 #   externally can create validation failures for that internal domain.
 #
+# [*stub_first*]
+#   (optional) Defaults to false. Controls 'stub-first' stub zone option.
+#   If true, a query that fails with the stub clause is attempted again
+#   without the stub clause.
+#
 # [*type*]
 #   (optional) Defaults to 'transparent', can be 'deny', 'refuse', 'static',
 #   'transparent', 'typetransparent', 'redirect' or 'nodefault'.
@@ -37,6 +42,7 @@ define unbound::stub (
   # lint:ignore:quoted_booleans
   Variant[Boolean, Enum['true', 'false']]            $insecure    = false,
   Variant[Boolean, Enum['true', 'false']]            $no_cache    = false,
+  Variant[Boolean, Enum['true', 'false']]            $stub_first  = false,
   # lint:endignore
   Unbound::Local_zone_type                           $type        = 'transparent',
   Optional[Stdlib::Unixpath]                         $config_file = undef,

--- a/spec/defines/stub_spec.rb
+++ b/spec/defines/stub_spec.rb
@@ -77,6 +77,29 @@ describe 'unbound::stub' do
         }
       end
 
+      context 'with stub_first set' do
+        let(:params) do
+          {
+            address: ['::1'],
+            stub_first: true
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_unbound__stub('lab.example.com') }
+
+        it {
+          expect(subject).to contain_concat__fragment('unbound-stub-lab.example.com').with(
+            content: <<~ZONE
+              stub-zone:
+                name: "lab.example.com"
+                stub-addr: ::1
+                stub-first: yes
+            ZONE
+          )
+        }
+      end
+
       context 'with address set as string' do
         let(:params) do
           {

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -6,6 +6,9 @@ stub-zone:
 <% @nameservers.each do |host| -%>
   stub-host: <%= host %>
 <% end -%>
+<% if @stub_first == 'true' or @stub_first == true -%>
+  stub-first: yes
+<% end -%>
 <% if @no_cache == 'true' or @no_cache == true -%>
   stub-no-cache: yes
 <% end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add support for stub-first stub zone option, which defaults to false.
It allows queries to be attempted again without the stub clause if
they failed with stub.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
