### PR TITLE
outgoing_port_permit_first: update to actually invert order

### DIFF
--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -40,8 +40,8 @@ server:
 <%= print_config('outgoing-port-permit', @outgoing_port_permit) -%>
 <%= print_config('outgoing-port-avoid', @outgoing_port_avoid) -%>
 <%- else -%>
-<%= print_config('outgoing-port-permit', @outgoing_port_avoid) -%>
 <%= print_config('outgoing-port-avoid', @outgoing_port_permit) -%>
+<%= print_config('outgoing-port-permit', @outgoing_port_avoid) -%>
 <%- end -%>
 <%= print_config('outgoing-num-tcp', @outgoing_num_tcp) -%>
 <%= print_config('incoming-num-tcp', @incoming_num_tcp) -%>


### PR DESCRIPTION
Currently this parameter has no effect.  This PR updates the code so the order of the values is actually inverted

fixes #313

