### PR TITLE
unbound.conf: prefer trust_anchor_file to auto_trust_anchor_file

### DIFF
--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -172,8 +172,11 @@ server:
 <%- unless @module_config.empty? %>
   module-config: "<%= @module_config.join(' ') %>"
 <%- end -%>
+<%- if @trust_anchor_file -%>
 <%= print_config('trust-anchor-file', @trust_anchor_file) -%>
+<%- else -%>
 <%= print_config('auto-trust-anchor-file', @auto_trust_anchor_file) -%>
+<%- end -%>
 <%= print_config('trust-anchor', @trust_anchor) -%>
 <%= print_config('trusted-keys-file', @trusted_keys_file) -%>
 <%= print_config('trust-anchor-signaling', @trust_anchor_signaling) -%>


### PR DESCRIPTION
The config only supports having trust_anchor_file or auto_trust_anchor_file.  this updates the code to use trust_anchor_file if it is set (its undef by default) otherwise use auto_trust_anchor_file which has a default value.

fixes #316
