### PR TITLE
Hiera and package management for Debian (made it for bookworm but could be usefull for any distro).

### DIFF
--- a/data/os/Debian/12.yaml
+++ b/data/os/Debian/12.yaml
@@ -1,0 +1,1 @@
+unbound::package_name: ['unbound','unbound-anchor']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,7 +172,7 @@ class unbound (
   String[1]                                     $owner                           = 'unbound',
   String[1]                                     $username                        = $owner,
   # OpenBSD sets this to an empty string
-  String                                        $package_name                    = 'unbound',
+  Variant[String,Array]                         $package_name                    = 'unbound',
   String[1]                                     $package_ensure                  = 'installed',
   Boolean                                       $purge_unbound_conf_d            = false,
   String[1]                                     $root_hints_url                  = 'https://www.internic.net/domain/named.root',


### PR DESCRIPTION
Hello, First time participant here.

#### Pull Request (PR) description
Couldn't install on Debian 12 because 'unbound-anchor' was missing. That command was moved to another package. Though it would be usefull to modify class to allow more than one package to be installed.
Added some hiera for Debian 12 as well.

#### This Pull Request (PR) fixes the following issues
(No Issue declared).