### PR TITLE
Add systemd timer to update root.hints file

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,3 +2,4 @@ fixtures:
   repositories:
     concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    systemd: "https://github.com/voxpupuli/puppet-systemd.git"

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [`unbound`](#unbound): Class: unbound  Installs and configures Unbound, the caching DNS resolver from NLnet Labs
+* [`unbound`](#unbound): Installs and configures Unbound, the caching DNS resolver from NLnet Labs
 * [`unbound::remote`](#unbound--remote): Class: unbound::remote  Configure remote control of the unbound daemon process  === Parameters:  [*enable*]   (optional) The option is used t
 
 ### Defined types
@@ -36,8 +36,6 @@
 
 ### <a name="unbound"></a>`unbound`
 
-Class: unbound
-
 Installs and configures Unbound, the caching DNS resolver from NLnet Labs
 
 #### Parameters
@@ -47,6 +45,7 @@ The following parameters are available in the `unbound` class:
 * [`hints_file`](#-unbound--hints_file)
 * [`hints_file_content`](#-unbound--hints_file_content)
 * [`unbound_version`](#-unbound--unbound_version)
+* [`update_root_hints`](#-unbound--update_root_hints)
 * [`manage_service`](#-unbound--manage_service)
 * [`verbosity`](#-unbound--verbosity)
 * [`statistics_interval`](#-unbound--statistics_interval)
@@ -273,6 +272,14 @@ Data type: `Optional[String[1]]`
 the version of the installed unbound instance. defaults to the fact, but you can overwrite it. this reduces the initial puppet runs from two to one
 
 Default value: `$facts['unbound_version']`
+
+##### <a name="-unbound--update_root_hints"></a>`update_root_hints`
+
+Data type: `Enum['absent','present','unmanaged']`
+
+If set to true (and hints_file isn't set to 'builtin') a systemd timer will be configured to update the root hints file every month
+
+Default value: `fact('systemd') ? { true => 'present', default => 'unmanaged'`
 
 ##### <a name="-unbound--manage_service"></a>`manage_service`
 

--- a/files/roothints.timer
+++ b/files/roothints.timer
@@ -1,0 +1,11 @@
+# THIS FILE IS MANAGED BY PUPPET
+# BASED ON https://wiki.archlinux.org/title/Unbound#Roothints_systemd_timer
+[Unit]
+Description=Run root.hints monthly
+
+[Timer]
+OnCalendar=monthly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/metadata.json
+++ b/metadata.json
@@ -113,6 +113,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.25.0 < 10.0.0"
+    },
+    {
+      "name": "puppet/systemd",
+      "version_requirement": ">= 6.3.0 < 7.0.0"
     }
   ]
 }

--- a/templates/roothints.service.epp
+++ b/templates/roothints.service.epp
@@ -1,0 +1,9 @@
+<%- | Stdlib::Absolutepath $hints_file, Stdlib::HTTPSUrl $root_hints_url, String[1] $fetch_client | -%>
+# THIS FILE IS MANAGED BY PUPPET
+# BASED ON https://wiki.archlinux.org/title/Unbound#Roothints_systemd_timer
+[Unit]
+Description=Update root hints for unbound
+After=network.target
+
+[Service]
+ExecStart=<%= $fetch_client %> <%= $hints_file %> <%= $root_hints_url %>


### PR DESCRIPTION
By default we download a root.hints file once. That's bad. it contains IP-addresses for all root DNS servers. Those addresses can change from time to time. We should update the file every now and then.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
