### PR TITLE
README: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ unbound::stub { "0.0.10.in-addr.arpa.":
 #
 # note that conf will be generated in the same order provided.
 unbound::stub { "10.0.10.in-addr.arpa.":
-  address    => [ 10.0.0.53', '10.0.0.10@10053'],
-  namservers => [ 'ns1.example.com', 'ns2.example.com' ],
+  address    => [ '10.0.0.53', '10.0.0.10@10053'],
+  nameservers => [ 'ns1.example.com', 'ns2.example.com' ],
 }
 ```
 


### PR DESCRIPTION
Fix small typos in `README.md`