### PR TITLE
Add support for interface_automatic_ports

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -55,6 +55,7 @@ The following parameters are available in the `unbound` class:
 * [`port`](#-unbound--port)
 * [`interface`](#-unbound--interface)
 * [`interface_automatic`](#-unbound--interface_automatic)
+* [`interface_automatic_ports`](#-unbound--interface_automatic_ports)
 * [`outgoing_interface`](#-unbound--outgoing_interface)
 * [`outgoing_range`](#-unbound--outgoing_range)
 * [`outgoing_port_permit`](#-unbound--outgoing_port_permit)
@@ -352,6 +353,14 @@ Data type: `Boolean`
 
 
 Default value: `false`
+
+##### <a name="-unbound--interface_automatic_ports_"></a>`interface_automatic_ports`
+
+Data type: `Optional[String[1]]`
+
+
+
+Default value: `undef`
 
 ##### <a name="-unbound--outgoing_interface"></a>`outgoing_interface`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -46,6 +46,7 @@ The following parameters are available in the `unbound` class:
 * [`hints_file_content`](#-unbound--hints_file_content)
 * [`unbound_version`](#-unbound--unbound_version)
 * [`update_root_hints`](#-unbound--update_root_hints)
+* [`interface_automatic_ports`](#-unbound--interface_automatic_ports)
 * [`manage_service`](#-unbound--manage_service)
 * [`verbosity`](#-unbound--verbosity)
 * [`statistics_interval`](#-unbound--statistics_interval)
@@ -55,7 +56,6 @@ The following parameters are available in the `unbound` class:
 * [`port`](#-unbound--port)
 * [`interface`](#-unbound--interface)
 * [`interface_automatic`](#-unbound--interface_automatic)
-* [`interface_automatic_ports`](#-unbound--interface_automatic_ports)
 * [`outgoing_interface`](#-unbound--outgoing_interface)
 * [`outgoing_range`](#-unbound--outgoing_range)
 * [`outgoing_port_permit`](#-unbound--outgoing_port_permit)
@@ -282,6 +282,14 @@ If set to true (and hints_file isn't set to 'builtin') a systemd timer will be c
 
 Default value: `fact('systemd') ? { true => 'present', default => 'unmanaged'`
 
+##### <a name="-unbound--interface_automatic_ports"></a>`interface_automatic_ports`
+
+Data type: `Optional[String[1]]`
+
+specifies the default ports to listen on when interface_automatic is also set to true, defaults to undef, specify as a string of space seperated ports e.g. "53 853 443"
+
+Default value: `undef`
+
 ##### <a name="-unbound--manage_service"></a>`manage_service`
 
 Data type: `Boolean`
@@ -353,14 +361,6 @@ Data type: `Boolean`
 
 
 Default value: `false`
-
-##### <a name="-unbound--interface_automatic_ports_"></a>`interface_automatic_ports`
-
-Data type: `Optional[String[1]]`
-
-
-
-Default value: `undef`
 
 ##### <a name="-unbound--outgoing_interface"></a>`outgoing_interface`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class unbound (
   Integer[0, 65535]                             $port                            = 53,
   Array[String[1]]                              $interface                       = [],
   Boolean                                       $interface_automatic             = false,
+  Optional[String[1]]                           $interface_automatic_ports       = undef,
   Array[String[1]]                              $outgoing_interface              = [],  # version 1.5.10
   Optional[Integer[1]]                          $outgoing_range                  = undef,
   Unbound::Range                                $outgoing_port_permit            = '32768-65535',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,8 @@
 #   the version of the installed unbound instance. defaults to the fact, but you can overwrite it. this reduces the initial puppet runs from two to one
 # @param update_root_hints
 #   If set to true (and hints_file isn't set to 'builtin') a systemd timer will be configured to update the root hints file every month
+# @param interface_automatic_ports
+#   specifies the default ports to listen on when interface_automatic is also set to true, defaults to undef, specify as a string of space seperated ports e.g. "53 853 443"
 #
 class unbound (
   Boolean                                       $manage_service                  = true,

--- a/templates/unbound.conf.erb
+++ b/templates/unbound.conf.erb
@@ -34,6 +34,9 @@ server:
 <%= print_config('port', @port) -%>
 <%= print_config('interface', @interface) -%>
 <%= print_config('interface-automatic', @interface_automatic) -%>
+<% if @interface_automatic_ports -%>
+<%= print_config('interface-automatic-ports', @interface_automatic_ports) -%>
+<% end -%>
 <%= print_config('outgoing-interface', @outgoing_interface) -%>
 <%= print_config('outgoing-range', @outgoing_range) -%>
 <%- if @outgoing_port_permit_first -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This PR enables support for configuring `interface-automatic-ports` which is available since unbound v 1.16 - by default its undef and will not inject the config variable so as to maintain backwards compatibility and defaults as per unbound config

#### This Pull Request (PR) fixes the following issues
None documented yet
