### PR TITLE
readme: fix stub nameserver typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ unbound::stub:
     address:
       - '10.0.0.53
       - '10.0.0.10@10053'
-    nameserveres:
+    nameservers:
       - 'ns1.example.com'
       - 'ns2.example.com'
 ```


### PR DESCRIPTION
Just a simple typo fix: 'nameserveres' -> 'nameservers' in README.md